### PR TITLE
updated queries to remove parameterization of generics

### DIFF
--- a/queries/Class.ql
+++ b/queries/Class.ql
@@ -1,12 +1,14 @@
 /**
  * @name Class
+ * @id java/example/class
+ * @description Gets all classess as well as their qualified module
  * @kind problem
  * @problem.severity warning
- * @description Get's all classess as well as their qualified module
- * @id java/example/classes
+
  */
 import java
+
 //TODO: remove javafx classes from query
 from Class c
 where c.getCompilationUnit().fromSource()
-select c.getName(), c.getPackage() + "." + c.getName()
+select c.getName(), c.getPackage() + "." + c.getName(), c.getNumberOfLinesOfCode()

--- a/queries/Extensions.ql
+++ b/queries/Extensions.ql
@@ -7,6 +7,18 @@
  */
 import java
 
-from ClassOrInterface c, ClassOrInterface superclass
-where superclass = c.getASourceSupertype() and superclass.getCompilationUnit().fromSource()
-select c.getPackage() + "." +c.getName(), superclass.getPackage() + "." + superclass.getName()
+boolean isGeneric(ClassOrInterface pt) {
+    if (pt instanceof ParameterizedType) then result = true
+    else result = false
+}
+
+  string getRepresentation(ClassOrInterface c) {
+    if (isGeneric(c) = false) then result = c.getPackage() + "." + c
+    else if (isGeneric(c) = true) then result = c.getPackage().toString() + "." + c.(ParameterizedType).getGenericType()
+    else result = "Something went wrong"
+}
+
+from ClassOrInterface c, Class superclass
+where superclass = c.getASourceSupertype() and superclass.getCompilationUnit().fromSource() 
+      and (not getRepresentation(c) = getRepresentation(superclass)) //Tuple<K,V> is derived from Tuple
+select getRepresentation(c), getRepresentation(superclass)        

--- a/queries/GenericInitialization.ql
+++ b/queries/GenericInitialization.ql
@@ -3,36 +3,35 @@
  * @kind problem
  * @problem.severity warning
  * @id java/example/object-initialization-generic
-* @description gets right-hand side of variable declarations (constructor) - when type is generic including all nested parameterized types
+ * @description gets right-hand side of variable declarations (constructor) - when type is generic including all nested parameterized types
  */
 
- import java
- import semmle.code.java.Generics
+import java
+import semmle.code.java.Generics
 
- boolean isGeneric(ClassOrInterface pt) {
+boolean isGeneric(ClassOrInterface pt) {
   if (pt instanceof ParameterizedType) then result = true
   else result = false
 }
  
- string getRepresentation(ClassOrInterface c) {
-  if (isGeneric(c) = false) then result = c.getPackage() + "." + c
-  else if (isGeneric(c) = true) then result = c.getPackage().toString() + "." + c.(ParameterizedType).getGenericType()
+string getRepresentation(ClassOrInterface c) {
+  if (isGeneric(c) = false) then result = c.getPackage() + "." + c.getName()
+  else if (isGeneric(c) = true) then result = c.getPackage().toString() + "." + c.(ParameterizedType).getGenericType().getName()
   else result = "Something went wrong"
 }
 
 
- from ConstructorCall call, ParameterizedType generic, ClassOrInterface child
-   //No circular constructor calls   
-   where call.getCaller().getDeclaringType() != call.getCallee().getDeclaringType() 
-
-   //Check for generics and all nested children
-   and call.getCallee().getDeclaringType() = generic and generic.getATypeArgument*() = child
+from ConstructorCall call, ParameterizedType generic, ClassOrInterface child
+//No circular constructor calls   
+where call.getCaller().getDeclaringType() != call.getCallee().getDeclaringType() 
+      //Check for generics and all nested children
+      and call.getCallee().getDeclaringType() = generic and generic.getATypeArgument*() = child
    
-   //Remove all generics that are tied to java
-   and child.fromSource()  
+      //Remove all generics that are tied to java
+      and child.getSourceDeclaration().fromSource()  
 
-   //If we don't want super() calls at all uncomment this:
-   //and (not call.callsSuper())
+      //If we don't want super() calls at all uncomment this:
+      //and (not call.callsSuper())
 
-   select getRepresentation(call.getCaller().getDeclaringType()), 
-          getRepresentation(child)
+select getRepresentation(call.getCaller().getDeclaringType()), 
+       getRepresentation(child)

--- a/queries/GenericInstantiation.ql
+++ b/queries/GenericInstantiation.ql
@@ -15,14 +15,14 @@ boolean isGeneric(ClassOrInterface pt) {
 }
 
 string getRepresentation(ClassOrInterface c) {
-    if (isGeneric(c) = false) then result = c.getPackage() + "." + c
-    else if (isGeneric(c) = true) then result = c.getPackage().toString() + "." + c.(ParameterizedType).getGenericType()
+    if (isGeneric(c) = false) then result = c.getPackage() + "." + c.getName()
+    else if (isGeneric(c) = true) then result = c.getPackage().toString() + "." + c.(ParameterizedType).getGenericType().getName()
     else result = "Something went wrong"
 }
 
 from VariableUpdate ass, ParameterizedType generic, ClassOrInterface child
 where ass.getDestVar().getType() = generic and generic.getATypeArgument*() = child
-and child.fromSource() //- Comment to filter out java libraries
+      and (child.getSourceDeclaration().fromSource()) //- Comment to filter out java libraries
 
 select getRepresentation(ass.getEnclosingCallable().getDeclaringType()), 
        getRepresentation(child)

--- a/queries/Implementations.ql
+++ b/queries/Implementations.ql
@@ -7,6 +7,18 @@
  */
 import java
 
+boolean isGeneric(ClassOrInterface pt) {
+    if (pt instanceof ParameterizedType) then result = true
+    else result = false
+}
+
+  string getRepresentation(ClassOrInterface c) {
+    if (isGeneric(c) = false) then result = c.getPackage() + "." + c
+    else if (isGeneric(c) = true) then result = c.getPackage().toString() + "." + c.(ParameterizedType).getGenericType()
+    else result = "Something went wrong"
+}
+
 from ClassOrInterface c, Interface superclass
 where superclass = c.getASourceSupertype() and superclass.getCompilationUnit().fromSource()
-select c.getPackage() + "." +c.getName(), superclass.getPackage() + "." + superclass.getName()
+      and (not getRepresentation(c) = getRepresentation(superclass)) //Tuple<K,V> is derived from Tuple
+select getRepresentation(c), getRepresentation(superclass)        

--- a/queries/Interface.ql
+++ b/queries/Interface.ql
@@ -1,11 +1,14 @@
 /**
  * @name Interface
+ * @id java/example/interface
+ * @description Gets all interfaces as well as their qualified module
  * @kind problem
  * @problem.severity warning
- * @description Gets all interfaces
- * @id java/example/interface
+
  */
 import java
+
+//TODO: remove javafx classes from query
 from Interface c
 where c.getCompilationUnit().fromSource()
-select c, c.getPackage() + "." + c.getName()
+select c.getName(), c.getPackage() + "." + c.getName(), c.getNumberOfLinesOfCode()


### PR DESCRIPTION
﻿## Checklists
### Types of changes
<!-- Put an 'x' in the box(es) that apply. -->
- [x] Fix (non-breaking change that fixes existing issue)
- [ ] Feature (non-breaking change that adds a feature)
- [ ] Breaking change (fix or feature that breaks or removes other functionality)
<!-- If none of the above apply, please add another box that applies -->

### Pre-flight checklist
<!-- Before going further with this PR please check the below checklist, and make sure you cover everything in it-->
- [ ] PR changes requires documentation change
- [ ] I have updated the documentation accordingly
- [ ] I have tested my change, and run all unit tests <!-- Further description required below -->
- [ ] I ran ``dotnet format`` and committed+pushed the result

## Description
<!-- Clear and concise description of your changes -->

Updated queries to better handle generic parameterization such that Tuple<K,V> is handled as Tupled.
Class.ql and Interface.ql now return linesOfCode() as array entry [2]

## Why
<!-- Why is this change necessary? What does it solve? -->
Generics were sometimes parameterized and wouldnt work

### Fixes issues:
<!-- If this PR fixes open issue(s) please link them here -->
<!-- If it doesnt, please open an issue and then link it here -->
- [x] #39 

## How has this been tested
<!-- If appropriate describe your testing strategy for the code in this PR. -->

## Screenshots of the solution (if appropriate)