### PR TITLE
Dependancy weight thickness & force directed layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "d3-force": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -6640,6 +6641,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
@@ -6647,6 +6661,14 @@
       "dependencies": {
         "d3-color": "1 - 3"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "d3-force": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/FloatingEdge.js
+++ b/src/FloatingEdge.js
@@ -3,11 +3,11 @@ import { useStore, getStraightPath } from 'reactflow';
 
 import { getEdgeParams } from './utils.js';
 
-function FloatingEdge({ id, source, target, markerEnd, data }) {
+function FloatingEdge({id, source, target, markerEnd, data}) {
     const sourceNode = useStore(useCallback((store) => store.nodeInternals.get(source), [source]));
     const targetNode = useStore(useCallback((store) => store.nodeInternals.get(target), [target]));
 
-    const { isSelected, nonSelected } = data;
+    const { isSelected, nonSelected, weight } = data;
     if (!sourceNode || !targetNode) {
         return null;
     }
@@ -25,8 +25,8 @@ function FloatingEdge({ id, source, target, markerEnd, data }) {
 
     const edgeStyle = {
         stroke: isSelected ?  "black" : "#b1b1b7",
-        strokeWidth: "2px",
-        opacity: isSelected ? "100%" : (nonSelected ? "75%" : "10%")
+        strokeWidth: `${Math.sqrt(weight) + 1}px`,
+        opacity: isSelected ? 1 : (nonSelected ? 0.75 : 0.1)
     }
 
     return (

--- a/src/Flow.js
+++ b/src/Flow.js
@@ -101,7 +101,7 @@ let NodeAsHandleFlow = () => {
       setSelectNode(null);
     }
   }
-
+  const [reactFlowInstance, setReactFlowInstance] = useState(null);
   return (
     <>
       <div className="panelHolder" id="leftFloat">
@@ -130,6 +130,7 @@ let NodeAsHandleFlow = () => {
         onNodeDoubleClick={expandPackage}
         onPaneClick={onPaneClicked}
         fitView
+        onLoad={(_reactFlowInstance) => setReactFlowInstance(_reactFlowInstance)}
         edgeTypes={edgeTypes}
         nodeTypes={nodeTypes}
         nodesConnectable={false}

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,17 +175,15 @@ export function createNodesAndEdges(param, useBarycenter, layout = 'force') {
                 const nodeTmp = tree.getNode(nodeId);
                 let nodeType;
                 if (nodeTmp.type === "class") {
-                    nodeType = 'classNode';
-                } else if (nodeTmp.type === "interface") {
-                    nodeType = 'interfaceNode';
                     const node = {
                         id: nodeId,
                         type: 'classNode',
                         data: {
                             id: nodeId,
-                            label: cls.name
+                            label: cls.name,
+                            isSelected: false
                         },
-                        position: { x: 0, y: 0 }
+                        position: { x: 0, y: 0}
                     }
                     nodes.push(node)
 
@@ -195,37 +193,24 @@ export function createNodesAndEdges(param, useBarycenter, layout = 'force') {
                         type: 'interfaceNode',
                         data: {
                             id: nodeId,
-                            label: cls.name
+                            label: cls.name,
+                            isSelected: false
                         },
-                        position: { x: 0, y: 0 }
+                        position: { x: 0, y: 0}
                     }
                     nodes.push(node)
                 }
-                const node = {
-                    id: nodeId,
-                    type: nodeType,
-                    data: {
-                        id: nodeId,
-                        label: cls.name,
-                        isSelected: false,
-                        weight: weight,
-                    },
-                    position: { x: 0, y: 0}
-                }
-                nodes.push(node)
             }
         } else {
-            // Create node for package
             const node = {
                 id: nodeId,
                 type: 'packageNode',
                 data: {
                     id: nodeId,
                     label: cls.name,
-                    isSelected: false,
-                    weight: weight,
+                    isSelected: false
                 },
-                position: { x: 0, y: 0 }
+                position: { x: 0, y: 0}
             }
             nodes.push(node)
         }


### PR DESCRIPTION
﻿## Checklists
### Types of changes
<!-- Put an 'x' in the box(es) that apply. -->
- [ ] Fix (non-breaking change that fixes existing issue)
- [x] Feature (non-breaking change that adds a feature)
- [ ] Breaking change (fix or feature that breaks or removes other functionality)
<!-- If none of the above apply, please add another box that applies -->

## Description
<!-- Clear and concise description of your changes -->
Added weight parameter to nodes which gets set to the amount of nested children in a package using the getNestedMembers function. If nested members shouldnt just be the nested classes/interfaces we can modify that function to include different members for weight calculation.

Forces in the force-directed graph layout can be tweaked, I will try to see if there are ways to avoid nodes overlapping unrelated edges (in the sense that the node is neither source nor target of the edge its overlapping). This is a difficult problem to solve, need to wield dual math katanas.

### Fixes issues:
<!-- If this PR fixes open issue(s) please link them here --> https://github.com/Markusgp/Untangle/issues/58

## Screenshots of the solution (if appropriate)
Circular layout
![msedge_qzZvhXTZkn](https://user-images.githubusercontent.com/5659949/228775289-a98c3fcb-40fb-413b-a13a-7d78498bc415.gif)

Force directed graph layout
![msedge_G0CHkNYH58](https://user-images.githubusercontent.com/5659949/228779526-db5ae842-8b4b-4659-b79f-66f61671d561.gif)
