### PR TITLE
Added showing circular dependencies and a filter for them

### DIFF
--- a/src/FloatingEdge.js
+++ b/src/FloatingEdge.js
@@ -7,7 +7,7 @@ function FloatingEdge({id, source, target, markerEnd, data}) {
     const sourceNode = useStore(useCallback((store) => store.nodeInternals.get(source), [source]));
     const targetNode = useStore(useCallback((store) => store.nodeInternals.get(target), [target]));
 
-    const { isSelected, nonSelected, weight } = data;
+    const { isSelected, nonSelected, weight, isCircular } = data;
     if (!sourceNode || !targetNode) {
         return null;
     }
@@ -24,7 +24,7 @@ function FloatingEdge({id, source, target, markerEnd, data}) {
     });
 
     const edgeStyle = {
-        stroke: isSelected ?  "black" : "#b1b1b7",
+        stroke: isCircular ? isSelected ? "red" : "#ca7461" : isSelected ? "black" : "#b1b1b7",
         strokeWidth: `${Math.sqrt(weight) + 1}px`,
         opacity: isSelected ? 1 : (nonSelected ? 0.75 : 0.1)
     }

--- a/src/Flow.js
+++ b/src/Flow.js
@@ -55,6 +55,7 @@ function Flow() {
   const [abstractionsToggled, setAbstractionsToggled] = useState(true);
   const [invocationsToggled, setInvocationsToggled] = useState(true);
   const [implementationsToggled, setImplementationsToggled] = useState(true);
+  const [circularToggled, setCircularToggled] = useState(true);
 
   const [selectedNode, setSelectNode] = useState(null);
   const [firstRender, setFirstRender] = useState(true);
@@ -78,7 +79,7 @@ function Flow() {
       return true;
     } else if (edge.label === "implements" && implementationsToggled) {
       return true;
-    }
+    } else if (edge.label === "circular" && circularToggled) return true;
     return false;
   }
 
@@ -241,7 +242,7 @@ useEffect(() => {
 
   return (<><div className="panelHolder" id="leftFloat">
     <div className="panelStyle">
-      <TogglePanel classesToggled={setClassesToggled} interfacesToggled={setInterfacesToggled} moduleToggled={setModulesToggled} implementationsToggled={setImplementationsToggled} abstractionsToggled={setAbstractionsToggled} invocationsToggled={setInvocationsToggled} />
+      <TogglePanel classesToggled={setClassesToggled} interfacesToggled={setInterfacesToggled} moduleToggled={setModulesToggled} implementationsToggled={setImplementationsToggled} abstractionsToggled={setAbstractionsToggled} invocationsToggled={setInvocationsToggled} circularToggled={setCircularToggled} />
     </div>
     <div className="panelStyle">
     <ExamplePanel>

--- a/src/FlowElements/Panels/TogglePanel.js
+++ b/src/FlowElements/Panels/TogglePanel.js
@@ -5,10 +5,10 @@ import { FaEyeSlash, FaEye } from "react-icons/fa";
 import { BiFilterAlt } from "react-icons/bi";
 
 
-const ExamplePanel = ({classesToggled, interfacesToggled, moduleToggled, implementationsToggled, abstractionsToggled, invocationsToggled}) => {
+const ExamplePanel = ({classesToggled, interfacesToggled, moduleToggled, implementationsToggled, abstractionsToggled, invocationsToggled, circularToggled}) => {
   const toggle = () => setOpen(!open);
   const nodeTypes = ["Classes", "Interfaces", "Modules"]
-  const edgeTypes = ["Invokes", "Inherits", "Implements"]
+  const edgeTypes = ["Invokes", "Inherits", "Implements", "Circular"]
   const eyeMap = new Map();
 
   const [classEye, setClassEye]=useState(true);
@@ -17,6 +17,7 @@ const ExamplePanel = ({classesToggled, interfacesToggled, moduleToggled, impleme
   const [abstractionEye, setAbstractionEye]=useState(true);
   const [implementationEye, setImplementationEye]=useState(true);
   const [invocationEye, setInvocationEye]=useState(true);
+  const [circularEye, setCircularEye]=useState(true);
 
   eyeMap.set("Classes", classEye);
   eyeMap.set("Interfaces", interfaceEye);
@@ -24,6 +25,7 @@ const ExamplePanel = ({classesToggled, interfacesToggled, moduleToggled, impleme
   eyeMap.set("Invokes", invocationEye);
   eyeMap.set("Inherits", abstractionEye);
   eyeMap.set("Implements", implementationEye)
+  eyeMap.set("Circular", circularEye)
   const eyeClick = (nodeType) => {
     switch (nodeType) {
       case "Classes": setClassEye(!classEye); classesToggled(!classEye); break;
@@ -32,6 +34,7 @@ const ExamplePanel = ({classesToggled, interfacesToggled, moduleToggled, impleme
       case "Invokes": setInvocationEye(!invocationEye); invocationsToggled(!invocationEye); break;
       case "Inherits": setAbstractionEye(!abstractionEye); abstractionsToggled(!abstractionEye); break;
       case "Implements": setImplementationEye(!implementationEye); implementationsToggled(!implementationEye); break;
+      case "Circular": setCircularEye(!circularEye); circularToggled(!circularEye); break;
     }
   }
   const nodeTypeItems = nodeTypes.map((nodeType) => <li className="nodesList" key={nodeType}>{eyeMap.get(nodeType) ? <FaEye className="faEye" onClick={() => eyeClick(nodeType)}/> : <FaEyeSlash className="faEye" onClick={() => eyeClick(nodeType)}/>} {nodeType} </li>)

--- a/src/utils.js
+++ b/src/utils.js
@@ -177,8 +177,8 @@ function calculateEdges(nodes) {
             return element.source === ele.target && element.target === ele.source
         });
         if (circularEdge !== undefined && nodes.find(a => a.id === ele.source || a.id === ele.target).type !== "packageNode") {
-            let test = edgesToBeAdded.find(a => { return a.id === `${ele.source}-circular-${ele.target}` || a.id === `${ele.target}-circular-${ele.source}`});
-            if (test === undefined) {
+            let edgeAlreadyFound = edgesToBeAdded.find(a => { return a.id === `${ele.source}-circular-${ele.target}` || a.id === `${ele.target}-circular-${ele.source}`});
+            if (edgeAlreadyFound === undefined) {
                 edgesToBeAdded.push({
                     id: `${ele.source}-circular-${ele.target}`,
                     source: ele.source,
@@ -190,7 +190,7 @@ function calculateEdges(nodes) {
                     data: {
                         isSelected: false,
                         nonSelected: true,
-                        weight: ele.data.weight,
+                        weight: ele.data.weight + circularEdge.data.weight,
                         isCircular: true,
                     },
                 })

--- a/src/utils.js
+++ b/src/utils.js
@@ -115,6 +115,7 @@ function calculateEdges(nodes) {
                     isSelected: false,
                     nonSelected: true,
                     weight: edgeWeight,
+                    isCircular: false,
                 }
             })
         })
@@ -139,6 +140,7 @@ function calculateEdges(nodes) {
                     isSelected: false,
                     nonSelected: true,
                     weight: edgeWeight,
+                    isCircular: false,
                 }
             })
         })
@@ -163,10 +165,39 @@ function calculateEdges(nodes) {
                     isSelected: false,
                     nonSelected: true,
                     weight: edgeWeight,
-                }
+                    isCircular: false,
+                },
             })
         })
     })
+    let edgesToBeAdded = []
+    edges.forEach(ele => {
+
+        let circularEdge = edges.find(element => {
+            return element.source === ele.target && element.target === ele.source
+        });
+        if (circularEdge !== undefined && nodes.find(a => a.id === ele.source || a.id === ele.target).type !== "packageNode") {
+            let test = edgesToBeAdded.find(a => { return a.id === `${ele.source}-circular-${ele.target}` || a.id === `${ele.target}-circular-${ele.source}`});
+            if (test === undefined) {
+                edgesToBeAdded.push({
+                    id: `${ele.source}-circular-${ele.target}`,
+                    source: ele.source,
+                    target: ele.target,
+                    type: "floating",
+                    animated: false,
+                    label: "circular",
+                    labelStyle: { fill: "#f6ab6c", fontWeight: 700 },
+                    data: {
+                        isSelected: false,
+                        nonSelected: true,
+                        weight: ele.data.weight,
+                        isCircular: true,
+                    },
+                })
+            }
+        }
+    })
+    edges = edges.concat(edgesToBeAdded)
     return edges
 }
 


### PR DESCRIPTION
﻿## Checklists
### Types of changes
<!-- Put an 'x' in the box(es) that apply. -->
- [ ] Fix (non-breaking change that fixes existing issue)
- [x] Feature (non-breaking change that adds a feature)
- [ ] Breaking change (fix or feature that breaks or removes other functionality)
<!-- If none of the above apply, please add another box that applies -->

### Pre-flight checklist
<!-- Before going further with this PR please check the below checklist, and make sure you cover everything in it-->
- [ ] PR changes requires documentation change
    - [ ] I have updated the documentation accordingly
- [ ] I have tested my change, and run all unit tests <!-- Further description required below -->

## Description
<!-- Clear and concise description of your changes -->
Added new edge "circular" with different color to make it easy to spot, as well as added the new edge in the filter.
![billede](https://user-images.githubusercontent.com/43517053/233054657-a265fea9-7bab-4e7a-91bf-614a52b65d96.png)
Right now it is implemented where the edges creating the circular dependencies are still drawn as the user could have interest in seeing the underlying edges based on the circular dependency

### Fixes issues:
<!-- If this PR fixes open issue(s) please link them here -->
<!-- If it doesnt, please open an issue and then link it here -->
- [x] #65 
